### PR TITLE
Fix domain split logic to allow dotcom domains

### DIFF
--- a/lib/olodum.js
+++ b/lib/olodum.js
@@ -132,7 +132,7 @@ function nativeDnsRequest(req, res) {
             // Check if ip is embedded in domain name e.g. 10-0-0-1.dev (where dev is filtered domain name)
             // if ip is present use it otherwise send to localhost
             if (d.length >= 2) {
-                var possibleIp = d[d.length - 2];
+                var possibleIp = d[0];
                 if (possibleIp.match(eipregex)) {
                     rip = possibleIp.replace(/-/g, '.'); //extract the ip
                 }


### PR DESCRIPTION
Currently, if development.com is used instead of development, 192-168-0-1.development.com resolves to 127.0.0.1 instead of 192.168.0.1. This change fixes that.